### PR TITLE
use dist-package instead of site-package

### DIFF
--- a/openrtm_aist_python/manifest.xml
+++ b/openrtm_aist_python/manifest.xml
@@ -9,8 +9,8 @@
 
 
   <export>
-    <python path="${prefix}/lib/python2.7/site-packages" />
-    <python path="${prefix}/lib/python2.7/site-packages/OpenRTM_aist/RTM_IDL" />
+    <python path="${prefix}/lib/python2.7/dist-packages" />
+    <python path="${prefix}/lib/python2.7/dist-packages/OpenRTM_aist/RTM_IDL" />
   </export>
 
   <rosdep name="python-omniorb" />


### PR DESCRIPTION
Specify dist-package instead of site-package in manifest.xml 
because libraries are installed to lib/python2.7/dist-package directory. 
