### PR TITLE
Give installed libraries execute permissions

### DIFF
--- a/openrtm_aist/catkin.cmake
+++ b/openrtm_aist/catkin.cmake
@@ -50,14 +50,16 @@ install(
   DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   USE_SOURCE_PERMISSIONS)
 install(
-  FILES ${CATKIN_DEVEL_PREFIX}/lib/libRTC-1.1.0.so
-        ${CATKIN_DEVEL_PREFIX}/lib/libRTC.a
-        ${CATKIN_DEVEL_PREFIX}/lib/libRTC.la
-        ${CATKIN_DEVEL_PREFIX}/lib/libRTC.so
-        ${CATKIN_DEVEL_PREFIX}/lib/libcoil-1.1.0.so
+  PROGRAMS ${CATKIN_DEVEL_PREFIX}/lib/libRTC-1.1.0.so
+           ${CATKIN_DEVEL_PREFIX}/lib/libRTC.la
+           ${CATKIN_DEVEL_PREFIX}/lib/libRTC.so
+           ${CATKIN_DEVEL_PREFIX}/lib/libcoil-1.1.0.so
+           ${CATKIN_DEVEL_PREFIX}/lib/libcoil.la
+           ${CATKIN_DEVEL_PREFIX}/lib/libcoil.so
+  DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+install(
+  FILES ${CATKIN_DEVEL_PREFIX}/lib/libRTC.a
         ${CATKIN_DEVEL_PREFIX}/lib/libcoil.a
-        ${CATKIN_DEVEL_PREFIX}/lib/libcoil.la
-        ${CATKIN_DEVEL_PREFIX}/lib/libcoil.so
   DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 install(
   FILES ${CATKIN_DEVEL_PREFIX}/lib/pkgconfig/libcoil.pc


### PR DESCRIPTION
All shared object libraries should have execute permissions. Using install will default the permissions to be like a normal file, which typically doesn't have execute permissions.

There is no cmake directive for installing libraries in this way, but the PROGRAMS directive is the same as FILES except that it gives execute permissions to installed files.

This was caught as a packaging error on Fedora.

Thanks!
