### PR TITLE
Update CHANGELOG.rst for 1.1.0-7

### DIFF
--- a/openrtm_aist/CHANGELOG.rst
+++ b/openrtm_aist/CHANGELOG.rst
@@ -4,5 +4,11 @@ Changelog for package openrtm_aist
 
 Forthcoming
 -----------
+* Give installed libraries execute permissions
+  All shared object libraries should have execute permissions. Using install will default the permissions to be like a normal file, which typically doesn't have execute permissions.
+* Contributors: Scott K Logan
+
+1.1.0-6 (2014-03-19)
+--------------------
 * Initial commit of CHANGELOG.rst
 * Contributors: Kei Okada, Ryohei Ueda, Isaac Isao Saito

--- a/openrtm_aist_core/CHANGELOG.rst
+++ b/openrtm_aist_core/CHANGELOG.rst
@@ -4,5 +4,8 @@ Changelog for package openrtm_aist_core
 
 Forthcoming
 -----------
+
+1.1.0-6 (2014-03-19)
+--------------------
 * Initial commit of CHANGELOG.rst
 * Contributors: Kei Okada, Ryohei Ueda, Isaac Isao Saito

--- a/openrtm_aist_python/CHANGELOG.rst
+++ b/openrtm_aist_python/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog for package openrtm_aist_python
 
 Forthcoming
 -----------
+* use SETUPTOOLS_ARG_EXTRA and python version for ArchLinux, see issue `#25 <https://github.com/start-jsk/openrtm_aist_core/issues/25>`_
+* Contributors: Kei Okada
+
+1.1.0-6 (2014-03-19)
+--------------------
 * fix default INSTALL_BIN_DIR, INSTALL_DATA_DIR and INSTALL_SCRIPT_DIR for rosbuild, fixes rosbild or Issue `#11 <https://github.com/start-jsk/openrtm_aist_core/issues/11>`_
 * Initial commit of CHANGELOG.rst
 * Contributors: Kei Okada, Ryohei Ueda, Isaac Isao Saito


### PR DESCRIPTION
I don't know if having build version number in `CHANGELOG.rst` is acceptable or not anywhere in ROS release cycle. Just understand the risk of having to revert/modify later.
