### PR TITLE
remove installed file if openrtm_aist_FOUND is not found, and do not con...

### DIFF
--- a/openrtm_aist/Makefile.openrtm_aist
+++ b/openrtm_aist/Makefile.openrtm_aist
@@ -15,6 +15,12 @@ MK_DIR      = $(shell rospack find mk)
 
 include $(MK_DIR)/download_unpack_build.mk
 
-installed: $(SOURCE_DIR)/unpacked
-	cd $(SOURCE_DIR) && ./configure --enable-debug --prefix=${INSTALL_DIR} --bindir=${INSTALL_BIN_DIR} --datarootdir=${INSTALL_DATA_DIR} && make -j`grep -c '^processor' /proc/cpuinfo` && make install
+clean:
+	cd $(SOURCE_DIR) && make clean
+
+$(SOURCE_DIR)/Makefile: $(SOURCE_DIR)/unpacked
+	cd $(SOURCE_DIR) && ./configure --enable-debug --prefix=${INSTALL_DIR} --bindir=${INSTALL_BIN_DIR} --datarootdir=${INSTALL_DATA_DIR}
+
+installed: $(SOURCE_DIR)/Makefile
+	cd $(SOURCE_DIR) && make -j`grep -c '^processor' /proc/cpuinfo` && make install
 	touch installed

--- a/openrtm_aist/catkin.cmake
+++ b/openrtm_aist/catkin.cmake
@@ -8,6 +8,9 @@ find_package(catkin REQUIRED mk rostest)
 # <devel>/lib/<package>/bin/rtcd
 # <devel>/lib/libRTC...
 # <src>/<package>/share
+if(NOT openrtm_aist_FOUND)
+  file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/installed)
+endif()
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/installed)
   execute_process(
     COMMAND cmake -E chdir ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
...figure when system runs make again

current openrtm_asit package fail to compile on following situation. this PR wil fixes.
this situation is similar to https://github.com/start-jsk/openhrp3/issues/44

```
catkin_make
rm -fr build/CMakeCache.txt
catkin_mail
```
